### PR TITLE
Don't process IPs if there are none

### DIFF
--- a/lib/vagrant-goodhosts/GoodHosts.rb
+++ b/lib/vagrant-goodhosts/GoodHosts.rb
@@ -89,6 +89,11 @@ module VagrantPlugins
         errorText = ""
         cli = get_cli
         hostnames_by_ips = generateHostnamesByIps
+
+        if not hostnames_by_ips.any?
+          return
+        end
+
         hostnames_by_ips.each do |ip_address, hostnames|
           if ip_address.nil?
             @ui.error "[vagrant-goodhosts] Error adding some hosts, no IP was provided for the following hostnames: #{hostnames}"
@@ -112,6 +117,11 @@ module VagrantPlugins
         errorText = ""
         cli = get_cli
         hostnames_by_ips = generateHostnamesByIps
+
+        if not hostnames_by_ips.any?
+          return
+        end
+
         hostnames_by_ips.each do |ip_address, hostnames|
           if ip_address.nil?
             @ui.error "[vagrant-goodhosts] Error adding some hosts, no IP was provided for the following hostnames: #{hostnames}"


### PR DESCRIPTION
This attempts to avoid an error message when using this plugin with vagrant files that do not use goodhosts.

Currently untested