### PR TITLE
Remove hosts on destroy, halt, and suspend

### DIFF
--- a/lib/vagrant-goodhosts/Action/RemoveHosts.rb
+++ b/lib/vagrant-goodhosts/Action/RemoveHosts.rb
@@ -5,15 +5,15 @@ module VagrantPlugins
 
         def run(env)
           machine_action = env[:machine_action]
-          if machine_action != :destroy || !@machine.id
-            if machine_action != :suspend || false != @machine.config.goodhosts.remove_on_suspend
-              if machine_action != :halt || false != @machine.config.goodhosts.remove_on_suspend
-                @ui.info "[vagrant-goodhosts] Removing hosts"
-                removeHostEntries
-              else
-                @ui.info "[vagrant-goodhosts] Removing hosts on suspend disabled"
-              end
-            end
+
+          return unless @machine.id
+          return unless [:destroy, :halt, :suspend].include? machine_action
+
+          if ([:halt, :suspend].include? machine_action) && (false == @machine.config.goodhosts.remove_on_suspend)
+            @ui.info "[vagrant-goodhosts] Removing hosts on suspend disabled"
+          else
+            @ui.info "[vagrant-goodhosts] Removing hosts"
+            removeHostEntries
           end
         end
 

--- a/lib/vagrant-goodhosts/config.rb
+++ b/lib/vagrant-goodhosts/config.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
         attr_accessor :disable_clean
         
         def initialize
+            @remove_on_suspend = true
             @disable_clean = true
         end
     end


### PR DESCRIPTION
Here's a potential fix for issue #37

I've tested the following situations:

| Command | remove_on_suspend = true | remove_on_suspend = false |
| --------------- | --------------- | --------------- |
| destroy | hosts removed | hosts removed |
| halt | hosts removed | hosts not removed |
| suspend | hosts removed | hosts not removed |

I need to point out that this fix highlights a problem with the `vagrant resume` command not executing the `UpdateHosts` action.