### PR TITLE
Ensure all actions are executed

### DIFF
--- a/lib/vagrant-goodhosts/Action/BaseAction.rb
+++ b/lib/vagrant-goodhosts/Action/BaseAction.rb
@@ -26,9 +26,10 @@ module VagrantPlugins
           # machines and having a static flag will result in a plugin being
           # executed just once.
           # https://github.com/goodhosts/vagrant/issues/30
-          if not @@completed.key?(@machine.name)
+          @@completed[@machine.name] = [] unless @@completed.key?(@machine.name)
+          unless @@completed[@machine.name].include? self.class.name
             run(env)
-            @@completed[@machine.name] = true
+            @@completed[@machine.name] << self.class.name
           end
 
           @app.call(env)


### PR DESCRIPTION
I've spotted an issue in the code that is designed to prevent the plugin executing multiple times.

For actions that have multiple hooks (reload and resume) it prevents all but the first hook from running.  In both cases the RemoveHosts action runs but the UpdateHosts action does not.

The `@@completed` hash used to track the executions is not granular enough to determine if specific actions have been completed, it is only able to determine if the whole plugin has been executed and blocks further executions.

I've tweaked the handling to use an array associated with the machine.  On the first execution of an action the action class name is added to the array and checks are put in place to see ensure that specific actions are not executed multiple times.

This addresses a problem I spotted when fixing issue #37 in PR #38.  The two probably need to go hand in hand but are in essence unrelated issues.