### PR TITLE
Remove hosts before adding them to cleanup older stale entries

### DIFF
--- a/lib/vagrant-goodhosts/plugin.rb
+++ b/lib/vagrant-goodhosts/plugin.rb
@@ -19,10 +19,12 @@ module VagrantPlugins
       end
 
       action_hook(:goodhosts, :machine_action_up) do |hook|
+        hook.prepend(Action::RemoveHosts)
         hook.append(Action::UpdateHosts)
       end
 
       action_hook(:goodhosts, :machine_action_boot) do |hook|
+        hook.prepend(Action::RemoveHosts)
         hook.append(Action::UpdateHosts)
       end
 


### PR DESCRIPTION
Untested, but this is what I meant when I said remove things before adding them. This _might_ fix it when VVV users update and the IP changes and they get 2 entries in their hosts file instead of 1 because the old one didn't get removed