### PR TITLE
Avoid ruby 2.5 requirement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     - 'Gemfile'
     - 'Rakefile'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.5
   Exclude:
     - 'Gemfile'
     - 'Rakefile'

--- a/lib/vagrant-goodhosts/GoodHosts.rb
+++ b/lib/vagrant-goodhosts/GoodHosts.rb
@@ -100,11 +100,12 @@ module VagrantPlugins
         hostnames_to_add = Array.new
         hostnames = hostnames.split
         # check which hostnames actually need adding
-        hostnames.each do |hostname|
-          address = Resolv.getaddress(hostname)
-          if address != ip_address
-            hostnames_to_add.append(hostname)
-          end
+        begin
+          hostnames.each do |hostname|
+            address = Resolv.getaddress(hostname)
+            if address != ip_address
+              hostnames_to_add.append(hostname)
+            end
         rescue StandardError => _e
           hostnames_to_add.append(hostname)
         end

--- a/lib/vagrant-goodhosts/GoodHosts.rb
+++ b/lib/vagrant-goodhosts/GoodHosts.rb
@@ -100,12 +100,14 @@ module VagrantPlugins
         hostnames_to_add = Array.new
         hostnames = hostnames.split
         # check which hostnames actually need adding
-        begin
-          hostnames.each do |hostname|
+        hostnames.each do |hostname|
+          begin
             address = Resolv.getaddress(hostname)
             if address != ip_address
               hostnames_to_add.append(hostname)
             end
+          rescue StandardError => _e
+            hostnames_to_add.append(hostname)
           end
         rescue StandardError => _e
           hostnames_to_add.append(hostname)

--- a/lib/vagrant-goodhosts/GoodHosts.rb
+++ b/lib/vagrant-goodhosts/GoodHosts.rb
@@ -106,6 +106,7 @@ module VagrantPlugins
             if address != ip_address
               hostnames_to_add.append(hostname)
             end
+          end
         rescue StandardError => _e
           hostnames_to_add.append(hostname)
         end

--- a/vagrant-goodhosts.gemspec
+++ b/vagrant-goodhosts.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name          = 'vagrant-goodhosts'
   s.version       = VagrantPlugins::GoodHosts::VERSION
   s.platform      = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.2'
   s.authors       = ['Daniele Scasciafratte']
   s.email         = ['mte90net@gmail.com']
   s.description   = "Enables Vagrant to update hosts file on the host machine with goodhosts"


### PR DESCRIPTION
We currently use this syntax added in Ruby v2.5:

https://bugs.ruby-lang.org/issues/12906

Older vagrant installs are updating to this version of goodhosts though and they use an older version of ruby, causing them to fail