### PR TITLE
Make goodhosts really work with Hyper-V

### DIFF
--- a/lib/vagrant-goodhosts/plugin.rb
+++ b/lib/vagrant-goodhosts/plugin.rb
@@ -31,15 +31,15 @@ module VagrantPlugins
       end
 
       action_hook(:goodhosts, :machine_action_halt) do |hook|
-        hook.append(Action::RemoveHosts)
+        hook.prepend(Action::RemoveHosts)
       end
 
       action_hook(:goodhosts, :machine_action_suspend) do |hook|
-        hook.append(Action::RemoveHosts)
+        hook.prepend(Action::RemoveHosts)
       end
 
       action_hook(:goodhosts, :machine_action_destroy) do |hook|
-        hook.append(Action::RemoveHosts)
+        hook.prepend(Action::RemoveHosts)
       end
 
       action_hook(:goodhosts, :machine_action_reload) do |hook|


### PR DESCRIPTION
Really solve #40 , use `read_guest_ip` to handle Hyper-V with dynamic IP.
Original `@machine.config.vm.provider :hyperv do ... end`'s block is never executed since provider configuration blocks are only possible to be executed in a very early stage(at least before VM boot, while `read_guest_ip` need booted VM), and its `read_guest_ip` usage is incorrect(Hyper-V driver's `read_guest_ip` accept 0 argument).

Also:
+ Remove useless `networks.empty?` check, since there is always the default forwarded_port network for ssh.
  + Note this removal does NOT make the code vulnerable, since `networks.each do |network| .... end` do nothing if `networks` is empty.
+ Correct action hooks timing: "add" after "up" should correspond to "remove" before "halt".
  + Without this, we cannot RemoveHosts when halting or destroying Hyper-V VM, since `read_guest_ip` can only work with running or suspended VMs.