### PR TITLE
Allow docker to add host entries

### DIFF
--- a/lib/vagrant-goodhosts/GoodHosts.rb
+++ b/lib/vagrant-goodhosts/GoodHosts.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       def get_ips
         ips = []
         if @machine.provider_name == :docker
+          @ui.info '[vagrant-goodhosts] Docker detected, adding 127.0.0.1 and ::1 IP addresses'
           ip = "127.0.0.1"
           ips.push(ip) unless ip.nil? or ips.include? ip
           ip = "::1"

--- a/lib/vagrant-goodhosts/GoodHosts.rb
+++ b/lib/vagrant-goodhosts/GoodHosts.rb
@@ -10,6 +10,13 @@ module VagrantPlugins
     module GoodHosts
       def get_ips
         ips = []
+        if @machine.provider_name == :docker
+          ip = "127.0.0.1"
+          ips.push(ip) unless ip.nil? or ips.include? ip
+          ip = "::1"
+          ips.push(ip) unless ip.nil? or ips.include? ip
+          return ips
+        end
         @machine.config.vm.networks.each do |network|
           key, options = network[0], network[1]
           if options[:goodhosts] == "skip"


### PR DESCRIPTION
This allows goodhosts to add hosts when using the docker provider, which in macOS doesn't allow to set a network IP accessible from the host, which means we have to rely solely on port forwarding.